### PR TITLE
Update python reset and button collision

### DIFF
--- a/Snek/GameOverStrategy.pde
+++ b/Snek/GameOverStrategy.pde
@@ -7,16 +7,10 @@ Button menu_button = new Button("Menu", 200, 200, 200, 100, (214));
 boolean buttonPressed;
   public GameOverStrategy() {
   }
-  void mouseClicked() {
-
-    if (menu_button.MouseIsOver()) {
-      buttonPressed = true;
-    }
-  }
-
+  
   @Override
     public void display() {
-    this.mouseClicked();
+    fill(255,0,0);
     textSize(40);
     text("Game Over", width / 2.5, 100);
     textSize(25);

--- a/Snek/MenuStrategy.pde
+++ b/Snek/MenuStrategy.pde
@@ -4,16 +4,6 @@ public class MenuStrategy implements ScreenStrategy {
   public MenuStrategy() {
   }
 
-//Bugged
-  //void mouseClicked() {
-  //  //play game button pressed
-  //  if (play_button.MouseIsOver()) {
-  //    //display play game screen
-  //    buttonPressed = true;
-  //  }
-  //}
-
-
 @Override
   public void display() {
   //this.mouseClicked();

--- a/Snek/Snek.pde
+++ b/Snek/Snek.pde
@@ -40,10 +40,16 @@ void draw() {
   if (currentScreen == 0) {
     menuScreen.display();
     if (menuScreen.buttonPressed) {
+      //reset python and score
       gameScreen.python.setXY(10, 10);
+      gameScreen.python.setSpeed(0,0);
       gameScreen.movementLock = "Up";
       score = 0;
+      keyCode = 0;
+      
       currentScreen = 1;
+      menuScreen.buttonPressed = false;
+      
     }
   }
   //play game screen
@@ -58,6 +64,7 @@ void draw() {
     gameOverScreen.display();
     if (gameOverScreen.buttonPressed) {
       currentScreen = 0;
+      gameOverScreen.buttonPressed = false;
     }
   }
 }
@@ -65,9 +72,9 @@ void collision() {
   //button color change
   if (currentScreen == 0) {
     if (menuScreen.play_button.MouseIsOver())
-      menuScreen.play_button.clr= color(180);
+      menuScreen.play_button.clr= color(150);
     else
-      menuScreen.play_button.clr= color(214);
+      menuScreen.play_button.clr= color(230);
   } else if (currentScreen == 2) {
     if (gameOverScreen.menu_button.MouseIsOver())
       gameOverScreen.menu_button.clr= color (180);
@@ -76,13 +83,14 @@ void collision() {
   }
  }
 
-//Note: Temporary have this here as mouseClicked is bugged inside menuStrategy, it doesnt detect clicks but simply detects intersection!
-//Same bug happens when u hover over the Menu button in the Gameover screen.
 void mouseClicked() {
     //play game button pressed
-    if (menuScreen.play_button.MouseIsOver()) {
+    if (menuScreen.play_button.MouseIsOver() && currentScreen == 0) {
       //display play game screen
-      currentScreen = 1;
+      menuScreen.buttonPressed = true;
+    }
+    if (gameOverScreen.menu_button.MouseIsOver() && currentScreen == 2) {
+      gameOverScreen.buttonPressed = true;
     }
   }
 

--- a/Snek/SnekHead.pde
+++ b/Snek/SnekHead.pde
@@ -1,7 +1,7 @@
 public class SnekHead{
     private int px;
     private int py;
-    private int sx = scl;
+    private int sx = 0;
     private int sy = 0;
     private SnekParts next = new SnekTail();
     private Boolean newPart = false;
@@ -14,13 +14,14 @@ public class SnekHead{
         this.sy = y;
     }
     
-    //temporary usage to reset snake upon game restart
+    //reset snake upon game restart
     public void setXY(int x, int y){
+      next = new SnekTail();
       this.px = x;
       this.py = y;
       this.sx = 0;
       this.sy = 0;
-      next = new SnekTail();
+      
     }
     public void setTrue(){
         this.newPart = true; 
@@ -35,8 +36,6 @@ public class SnekHead{
         int prevy = this.py;
         this.px += this.sx;
         this.py += this.sy;
-        //this.px = constrain(this.px, 10, width-10);
-        //this.py = constrain(this.py, 10, height-10);
         this.draw();
         if(newPart){
             newPart = false;


### PR DESCRIPTION
Moved mouse clicked function in all game screen strategies to Snek.pde.

Added variables to reset the python upon game restart

Having mouse clicked within game strategies caused an bug with button collision that was solved by having a single mouseclicked function in Snek.pde. keyCode = 0 required because system stored the last key pressed in keyCode variable causing python to move in that direction.

As a result, buttons now trigger properly upon mouse click and python is fully reset after game restart.